### PR TITLE
Use `macos-15` to build macos wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -43,7 +43,7 @@ jobs:
           - os: windows-latest
             archs: "x86"
             impl: win
-          - os: macos-15-intel
+          - os: macos-15
             archs: "universal2"
             impl: macosx
       fail-fast: false

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -43,7 +43,7 @@ jobs:
           - os: windows-latest
             archs: "x86"
             impl: win
-          - os: macos-13
+          - os: macos-15-intel
             archs: "universal2"
             impl: macosx
       fail-fast: false


### PR DESCRIPTION
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/